### PR TITLE
Update installation instructions to override default options for `install_github()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can install the released version of inauguration from GitHub with
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("ciannabp/inauguration")
+devtools::install_github("ciannabp/inauguration", ref="main")
 ```
 
 ## Usage


### PR DESCRIPTION
Hi, there! Thanks for your wonderful color palettes. This is just a little PR to update the `install_github()` command to reflect `main` branch nomenclature, which isn't currently the function default.